### PR TITLE
Java8 compatibility

### DIFF
--- a/modules/filesystem/module.xml
+++ b/modules/filesystem/module.xml
@@ -14,6 +14,10 @@
 	<target name="create-directories">
         <script language="javascript">
             <![CDATA[
+                // this load lines are needed for Java8 compatibility - with falback
+                try {
+                    load("nashorn:mozilla_compat.js");
+                } catch (e) {}
             	importClass(java.io.File);
                 var paths = project.getProperty('mkdir');
                 if (paths != undefined) {
@@ -83,6 +87,10 @@
         <propertyselector property="modes" delimiter="," match="chmod.(\d+)" select="\1" />
         <script language="javascript">
             <![CDATA[
+                // this load lines are needed for Java8 compatibility - with falback
+                try {
+                    load("nashorn:mozilla_compat.js");
+                } catch (e) {}
                 importClass(java.io.File);
                 var modes = project.getProperty('modes');
                 if (modes != undefined) {


### PR DESCRIPTION
Hello,

Ananas does noes work with Oracle java8: we have a `ReferenceError: "importClass" is not defined in at line number 3` error, since JS implementation changed and some functions were removed.
Fortunately those were added a in compat package ; here we try to load it (it fails silently if it does not exist, so java7 still works).
