### PR TITLE
[meteor] Change meteor dependency installation

### DIFF
--- a/modules/meteor/module.xml
+++ b/modules/meteor/module.xml
@@ -11,10 +11,10 @@
 
     <target name="meteor.build_bundle">
         <exec executable="${meteor.executable}" dir="${project.dirs.base}/${meteor.src}">
-            <arg line="build --directory ${project.dirs.base}/${meteor.build-dir}" />
+            <arg line="npm install" />
         </exec>
-        <exec executable="${npm.executable}" dir="${project.dirs.base}/${meteor.build-dir}/bundle/programs/server">
-            <arg line="install" />
+        <exec executable="${meteor.executable}" dir="${project.dirs.base}/${meteor.src}">
+            <arg line="build --directory ${project.dirs.base}/${meteor.build-dir}" />
         </exec>
     </target>
 </project>


### PR DESCRIPTION
Since version 1.3, Meteor now uses mainly npm for package manager. As stated here : https://guide.meteor.com/atmosphere-vs-npm.html, atmosphere will progressively be replaced by npm so, we need to do a `meteor npm install` before building node packaged version of the sources.